### PR TITLE
Add support for linux. Include all classpaths, not only runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ sbtPlugin := true
 
 organization := "com.persist"
 
-version := "1.0.0"
+version := "1.0.1"
 
 scalaVersion := "2.10.4"
 


### PR DESCRIPTION
Hey, nice plugin, but did not work for me. I have updated it so it can work on linux (at least my machine - Debian).

Changes:
- version bump to 1.0.1
- detect OS, use appropriate command for opening browser
- tar on my machine cannot extract jar, dont know why. So on Linux, it uses unzip now

Hope I did not break anything for you, OSX users :)
